### PR TITLE
Generate comprehensive api documentation

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,15 @@
+# Handlebars API Reference
+
+This section documents the public APIs, functions, and components exposed by this repository. Each page includes examples and usage instructions.
+
+- Core
+  - [Handlebars Object](./core.md)
+  - [Runtime and VM](./runtime.md)
+  - [Utils, SafeString, Exception](./utils.md)
+- Helpers and Decorators
+  - [Built-in Helpers](./helpers.md)
+  - [Decorators](./decorators.md)
+- Tooling
+  - [CLI](./cli.md)
+  - [Compiler APIs](../compiler-api.md)
+  - [TypeScript Types](./types.md)

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -1,0 +1,51 @@
+# CLI
+
+The `handlebars` CLI precompiles templates for use with the runtime.
+
+Usage:
+```bash
+handlebars [template|directory]... [options]
+```
+
+Options:
+- `-f, --output <file>`: Write output to file
+- `--map <file>`: Write source map to file
+- `-a, --amd`: Export AMD module
+- `-c, --commonjs <path>`: Export CommonJS module; specify path to Handlebars
+- `-h, --handlebarPath <path>`: Path to `handlebars.js` for AMD
+- `-k, --known <name>`: Mark helper as known (can be repeated)
+- `-o, --knownOnly`: Only allow known helpers
+- `-m, --min`: Minimize output (requires `uglify-js` in deps)
+- `-n, --namespace <ns>`: Global namespace for templates (default `Handlebars.templates`)
+- `-s, --simple`: Output template function only
+- `-N, --name <name>`: Name for string templates (required for multiple `-i`)
+- `-i, --string <template>`: Template string, `-` reads from stdin
+- `-r, --root <path>`: Template root to strip from names
+- `-p, --partial`: Compile as partial
+- `-d, --data`: Include `data` support
+- `-e, --extension <ext>`: Template extension (default `handlebars`)
+- `-b, --bom`: Remove UTF-8 BOM
+- `-v, --version`: Print compiler/runtime version
+- `--help`: Show help
+
+Examples:
+
+- Precompile a single template to stdout:
+```bash
+handlebars views/welcome.handlebars -s
+```
+
+- Precompile a directory to a namespace:
+```bash
+handlebars views -f public/templates.js -n MyApp.Templates
+```
+
+- Read from stdin and name the template:
+```bash
+echo "<p>{{name}}</p>" | handlebars -i - -s -N card
+```
+
+- Generate source map and minify:
+```bash
+handlebars views -f public/templates.js --map public/templates.js.map -m
+```

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -1,0 +1,77 @@
+# Core: Handlebars Object
+
+The `Handlebars` object is the primary API surface. In Node, require it via `require('handlebars')`; in ESM/bundlers, import the default export from `lib/handlebars.js` (or use the published package).
+
+## Getting an Instance
+
+```js
+const Handlebars = require('handlebars');
+// or create an isolated environment
+const hbs = Handlebars.create();
+```
+
+`create()` returns a new isolated environment with its own helpers, partials, and decorators.
+
+## Core Methods
+
+- `compile(template: string | AST, options?: CompileOptions): TemplateDelegate`
+  - Compiles a template string or AST into a render function.
+  - Example:
+    ```js
+    const template = Handlebars.compile('Hello {{name}}!');
+    console.log(template({ name: 'World' })); // "Hello World!"
+    ```
+
+- `precompile(template: string | AST, options?: PrecompileOptions): TemplateSpecification`
+  - Produces a precompiled specification string or object to use with `template()` at runtime.
+
+- `template(spec: TemplateSpecification): TemplateDelegate`
+  - Converts a precompiled spec into an executable template function (usually used by the runtime or CLI output).
+
+- `parse(source: string): AST` and `parseWithoutProcessing(source: string): AST`
+  - Parse a template into an AST (see `docs/compiler-api.md`).
+
+- `create(): typeof Handlebars`
+  - Creates a new environment where you can register helpers/partials without affecting the global instance.
+
+## Registration APIs
+
+- `registerHelper(name: string, fn: HelperDelegate): void`
+- `registerHelper(spec: Record<string, HelperDelegate>): void`
+- `unregisterHelper(name: string): void`
+
+- `registerPartial(name: string, template: Template | TemplateDelegate): void`
+- `registerPartial(spec: Record<string, Template | TemplateDelegate>): void`
+- `unregisterPartial(name: string): void`
+
+- `registerDecorator(name: string, fn: Function): void`
+- `registerDecorator(spec: Record<string, Function>): void`
+- `unregisterDecorator(name: string): void`
+
+Example:
+```js
+const hbs = Handlebars.create();
+hbs.registerHelper('upper', (v) => String(v).toUpperCase());
+const out = hbs.compile('{{upper name}}')({ name: 'Ada' });
+// out => 'ADA'
+```
+
+## Properties
+
+- `VERSION: string`
+- `helpers: Record<string, HelperDelegate>`
+- `partials: Record<string, any>`
+- `decorators: Record<string, Function>`
+- `logger: Logger` and `log(level: number, ...args)`
+- `AST`, `Compiler`, `JavaScriptCompiler`, `Parser`, `Visitor` (advanced)
+- `Exception`, `SafeString`, `Utils`, `escapeExpression`
+
+## No Conflict
+
+- `noConflict(): typeof Handlebars`
+  - Restores any previous global `Handlebars` and returns the current instance.
+
+## Error Handling
+
+- `Exception(message: string, node?: AST.Node)` creates an error that includes location data when available.
+

--- a/docs/api/decorators.md
+++ b/docs/api/decorators.md
@@ -1,0 +1,27 @@
+# Decorators
+
+Decorators run when a block is instantiated and can modify the block function or attach metadata.
+
+## inline
+
+Registers an inline partial available only within the current scope.
+
+Syntax:
+```hbs
+{{#*inline "row"}}
+  <tr><td>{{this}}</td></tr>
+{{/inline}}
+
+<table>
+  {{#each items}}
+    {{> row}}
+  {{/each}}
+</table>
+```
+
+Behavior:
+- Injects the decorated block as a partial with the given name onto the current partials frame.
+- Restores the previous partials map after execution.
+
+Notes:
+- Decorators are considered advanced and are deprecated for future removal. See `docs/decorators-api.md` for details.

--- a/docs/api/helpers.md
+++ b/docs/api/helpers.md
@@ -1,0 +1,83 @@
+# Built-in Helpers
+
+The following helpers are registered by default in every environment.
+
+## #if / #unless
+
+Conditional rendering based on truthiness and emptiness.
+
+- `{{#if cond}}...{{else}}...{{/if}}`
+- `{{#unless cond}}...{{/unless}}` (inverse of `if`)
+
+Notes:
+- Functions passed as `cond` are invoked to get the value.
+- By default, `0`, `''`, `null`, `undefined`, `[]` are treated as empty. Use `includeZero=true` to treat `0` as non-empty.
+
+Example:
+```hbs
+{{#if isAdmin}}
+  Welcome, admin!
+{{else}}
+  Welcome, user.
+{{/if}}
+
+{{#unless items}}
+  No items.
+{{/unless}}
+```
+
+## #each
+
+Iterate arrays, objects, Maps, Sets, or any iterable. Provides block params and data like `@index`, `@first`, `@last`.
+
+Example:
+```hbs
+<ul>
+  {{#each items}}
+    <li>{{@index}}: {{this}}</li>
+  {{/each}}
+</ul>
+```
+
+Block params example:
+```hbs
+{{#each object as |value key|}}
+  {{key}} = {{value}}
+{{/each}}
+```
+
+## #with
+
+Switch context to a non-empty value, otherwise renders `{{else}}`.
+
+```hbs
+{{#with user}}
+  Name: {{name}}
+{{else}}
+  No user
+{{/with}}
+```
+
+## log
+
+Logs messages via the Handlebars logger.
+
+```hbs
+{{log "loading" level="debug"}}
+```
+
+Level resolution order: `hash.level`, then `@data.level`, default `info`.
+
+## lookup
+
+Looks up a property by name while respecting runtime proto-access rules.
+
+```hbs
+{{lookup user "name"}}
+```
+
+## helperMissing / blockHelperMissing
+
+Internal hooks invoked when a helper or block helper is not found.
+- `helperMissing` returns `undefined` for `{{foo}}` and throws for `{{foo bar}}`.
+- `blockHelperMissing` renders arrays with `each`, booleans as truthy/falsey blocks, or treats context objects as the context for the block.

--- a/docs/api/runtime.md
+++ b/docs/api/runtime.md
@@ -1,0 +1,40 @@
+# Runtime and VM
+
+The runtime provides utilities used by precompiled templates and exposes the VM functions used internally.
+
+## Runtime Methods
+
+- `template(spec, env)`
+  - Validates a precompiled `spec` and returns a render function bound to `env` (a Handlebars environment).
+
+- `checkRevision(compilerInfo)`
+  - Throws if the template was precompiled with an incompatible compiler.
+
+- `resolvePartial(partial, context, options)` and `invokePartial(partial, context, options)`
+  - Resolve and invoke named or dynamic partials.
+
+- `noop()`
+  - Returns an empty string. Useful for default block functions.
+
+These methods are available on `Handlebars.VM` and used by `Handlebars.template()`.
+
+## Environment and Defaults
+
+A newly created environment registers default helpers and the `inline` decorator. Helper hooks like `helperMissing` and `blockHelperMissing` are moved into the `hooks` map during rendering setup.
+
+## Logger
+
+The logger is exposed via `Handlebars.logger` and `Handlebars.log(level, ...args)`.
+
+- Levels: `0: debug`, `1: info`, `2: warn`, `3: error`
+- Configure: `Handlebars.logger.level = 'warn'` or a number.
+
+Example:
+```js
+Handlebars.log('info', 'Compiling templates');
+Handlebars.logger.level = 'error';
+```
+
+## No Conflict
+
+`Handlebars.noConflict()` restores any previous global `Handlebars` when used in browser environments and returns the current instance.

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -1,0 +1,23 @@
+# TypeScript Types
+
+The package provides TypeScript types via `types/index.d.ts`.
+
+Key types:
+- `Handlebars.TemplateDelegate<T>`: `(context: T, options?: RuntimeOptions) => string`
+- `Handlebars.RuntimeOptions`: Flags for rendering, helpers, partials, decorators, `data`, and proto-access defaults.
+- `CompileOptions` and `PrecompileOptions`: Control compilation output.
+- `Logger`: Interface for `Handlebars.logger`.
+- `CompilerInfo`: Tuple `[revision: number, versions: string]` used for runtime checks.
+
+Example usage:
+```ts
+import Handlebars, { HandlebarsTemplateDelegate, CompileOptions } from 'handlebars';
+
+const tmpl: HandlebarsTemplateDelegate<{ name: string }> = Handlebars.compile(
+  'Hello {{name}}!'
+);
+
+const html = tmpl({ name: 'TypeScript' });
+```
+
+Ambient module `"handlebars/runtime"` maps to the runtime-only bundle for projects that only ship precompiled templates.

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -1,0 +1,35 @@
+# Utils, SafeString, Exception
+
+## Utils
+
+Common utility helpers exposed at `Handlebars.Utils` and also available individually on the module:
+
+- `escapeExpression(str: string): string`
+  - Escapes HTML special characters. Respects `SafeString` instances.
+- `createFrame(object: any): any`
+  - Shallow-copies `object` and adds `_parent` link. Used for `@data` frames.
+- `extend(target, ...sources): any`
+  - Shallow merge of enumerable own properties.
+- `isEmpty(value): boolean`
+  - True for falsy values (except `0`) and empty arrays.
+- `isArray(value): boolean`, `isFunction(value): boolean`, `isMap(value): boolean`, `isSet(value): boolean`
+
+Example:
+```js
+const { Utils } = Handlebars;
+const safe = Utils.escapeExpression('<b>'); // &lt;b&gt;
+```
+
+## SafeString
+
+`new Handlebars.SafeString(html)` marks a string as HTML-safe.
+
+```js
+const name = new Handlebars.SafeString('<em>Ada</em>');
+Handlebars.compile('Hello {{name}}!')({ name });
+// => Hello <em>Ada</em>!
+```
+
+## Exception
+
+`Handlebars.Exception(message: string, node?: AST.Node)` constructs an error used across the library, optionally including AST location information.


### PR DESCRIPTION
Before creating a pull-request, please check https://github.com/handlebars-lang/handlebars.js/blob/master/CONTRIBUTING.md first.

Generally we like to see pull requests that

- [ ] Please don't start pull requests for security issues. Instead, file a report at https://www.npmjs.com/advisories/report?package=handlebars
- [x] Maintain the existing code style
- [x] Are focused on a single change (i.e. avoid large refactoring or style adjustments in untouched code if not the primary goal of the pull request)
- [ ] Have good commit messages
- [ ] Have tests
- [ ] Have the [typings](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) (types/index.d.ts) updated on every API change. If you need help, updating those, please mention that in the PR description.
- [ ] Don't significantly decrease the current code coverage (see coverage/lcov-report/index.html)
- [x] Currently, the `4.x`-branch contains the latest version. Please target that branch in the PR.

This PR introduces comprehensive API documentation under `docs/api/`.

The goal is to provide a centralized and detailed reference for all public APIs, functions, and components, improving developer experience and onboarding.

The new documentation covers:
- The core `Handlebars` object, its methods, and registration APIs.
- Runtime and VM functionalities.
- Built-in helpers (`if`, `each`, `with`, `log`, `lookup`, etc.).
- Decorators (e.g., `inline`).
- Utility functions (`escapeExpression`, `SafeString`, `Exception`).
- CLI usage and options.
- Key TypeScript types.

Each section includes examples and usage instructions to make the public API more understandable and easier to use.

---
<a href="https://cursor.com/background-agent?bcId=bc-df6c3f09-b723-417e-a64c-3ffb4231d3a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-df6c3f09-b723-417e-a64c-3ffb4231d3a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

